### PR TITLE
add type="module" to script tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -76,7 +76,7 @@
 				<div class="layout__faboolea"><a class="layout__faboolea-link" href="https://twitter.com/faboolea">Made by &nbsp; ꜰᴀʙᴏᴏʟᴇᴀ</a></div>
 			</div>
 		</main>
-		<script src="./app/index.js"></script>
+		<script type="module" src="./app/index.js"></script>
 		<!--script src="https://tympanus.net/codrops/adpacks/cda.js"></script-->
 	</body>
 </html>


### PR DESCRIPTION
Otherwise parcel 2 throws a build error: "Browser scripts cannot have imports or exports"

As discussed here:
https://github.com/parcel-bundler/parcel/discussions/6490 https://parceljs.org/blog/rc0/

Thanks for the cool repo btw!